### PR TITLE
Request Size Up

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,6 @@
 export const serviceWorkerService =
   "https://pwabuilder-sw-server.azurewebsites.net/download";
 export const DefaultServiceWorkerId = 1;
+
+
+export const BinaryMegabyteSize = 1048576;

--- a/src/web.test.ts
+++ b/src/web.test.ts
@@ -1,0 +1,1 @@
+import * as web from "./web"

--- a/src/web.test.ts
+++ b/src/web.test.ts
@@ -1,1 +1,0 @@
-import * as web from "./web"

--- a/src/web.ts
+++ b/src/web.ts
@@ -4,7 +4,7 @@ import fetch from "got";
 import { handleIcons } from "./icons";
 import { FilesAndEdit, copyFiles, copyFile } from "./copy";
 import { webAppManifestSchema } from "./schema";
-import { DefaultServiceWorkerId, serviceWorkerService } from "./constants";
+import { BinaryMegabyteSize, DefaultServiceWorkerId, serviceWorkerService } from "./constants";
 import { handleScreenshots } from "./screenshots";
 import { writeFile } from "./write";
 
@@ -38,6 +38,7 @@ export default function web(server: FastifyInstance) {
     method: "POST",
     url: "/",
     schema: schema(server),
+    bodyLimit: 24 * BinaryMegabyteSize,
     handler: async function (request, reply) {
       try {
         const zip = new JSZip();


### PR DESCRIPTION
Bumping it up from 1 mb to 24 mb. Should be sufficient for most pwas. Will follow up with form data support.