### PR TITLE
Service to handle base 64 images

### DIFF
--- a/src/images.ts
+++ b/src/images.ts
@@ -1,13 +1,36 @@
-import * as Url from "url";
+import { FastifyInstance } from 'fastify';
+import Jimp from 'jimp';
+import * as Url from 'url';
 
 export function isBase64(uri: string): boolean {
-  return uri.startsWith("data:") && uri.indexOf("base64") !== -1;
+  return uri.startsWith('data:') && uri.indexOf('base64') !== -1;
 }
 
 export function handleUrl(url: string, baseUrl: string): string {
   if (isBase64(url)) {
-    return url;
+    return url.split(',').pop() as string;
   } else {
     return new Url.URL(url, baseUrl).toString();
   }
+}
+
+export async function getJimp(
+  image: ManifestImageResource,
+  baseUrl: string,
+  server?: FastifyInstance
+): Promise<Jimp | undefined> {
+  try {
+    const url: string = handleUrl(image.src, baseUrl);
+
+    if (isBase64(image.src)) {
+      const imgBuf = Buffer.from(image.src.split(',')[1], 'base64');
+      return Jimp.read(imgBuf);
+    }
+
+    return Jimp.read(url);
+  } catch (e) {
+    server?.log.info(e);
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
- the issue was that I thought Jimp could handle the front matter and ignore it, transforming it into a base64 image, but that wasn't the case, we need to manually convert it into base64 in a buffer.


- outstanding issues, the quality of the image can be hit or miss. Going to investigate the best way to handle that.