### PR TITLE
ensure the image is at parity

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -72,12 +72,21 @@ export async function handleIcons(
 
         const iconName = `${iconEntry.sizes}.` + icon.getExtension();
         const iconMIME = icon.getMIME();
+        const width = icon.bitmap.width;
+        const height = icon.bitmap.height;
+
         filePath = `images/${iconName}`;
 
         operations.push(
           (async () => {
             try {
-              zip.file(filePath, await icon.getBufferAsync(iconMIME));
+              zip.file(
+                filePath,
+                await icon
+                  .quality(100)
+                  .resize(width, height)
+                  .getBufferAsync(iconMIME)
+              );
               manifest.icons[i].src = filePath;
 
               return {

--- a/src/screenshots.ts
+++ b/src/screenshots.ts
@@ -30,6 +30,8 @@ export async function handleScreenshots(
           );
           continue;
         }
+        const width = screenshot.bitmap.width;
+        const height = screenshot.bitmap.height;
 
         filePath = `screenshots/${handleScreenshotName(
           screenshotEntry,
@@ -43,7 +45,10 @@ export async function handleScreenshots(
             try {
               zip.file(
                 filePath,
-                await screenshot.getBufferAsync(screenshotMIME)
+                await screenshot
+                  .quality(100)
+                  .resize(width, height)
+                  .getBufferAsync(screenshotMIME)
               );
               manifest.screenshots[i].src = filePath;
 


### PR DESCRIPTION
keep the image size the same, tricked by bad test data