### PR TITLE
types, test, slight refactor

### DIFF
--- a/__tests__/icons.test.ts
+++ b/__tests__/icons.test.ts
@@ -29,7 +29,7 @@ const mockManifest: WebAppManifest = {
   screenshots: [],
   categories: [],
   iarc_rating_id: 'ignore',
-  prefer_related_applications: 'true',
+  prefer_related_applications: true,
 };
 
 describe('icons', () => {

--- a/__tests__/screenshots.test.ts
+++ b/__tests__/screenshots.test.ts
@@ -25,7 +25,7 @@ const mockManifest: WebAppManifest = {
   screenshots: [],
   categories: [],
   iarc_rating_id: 'ignore',
-  prefer_related_applications: 'true',
+  prefer_related_applications: true,
 };
 
 describe('screenshots.ts', () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,162 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { generateObjectFromFormData } from '../src/utils';
+
+describe('generateObjectFromFormData()', () => {
+  it('bus boy parsed manifest (normal scenario)', () => {
+    const mockManifestIcons = [
+      {
+        src: 'a.png',
+        type: 'image/png',
+        sizes: '512x512',
+        purpose: 'any',
+      },
+      {
+        src: 'b.png',
+        type: 'image/png',
+        sizes: '16x16 32x32',
+        purpose: 'any',
+      },
+    ];
+    const mockManifestScreenshots = [
+      {
+        src: 'c.png',
+        type: 'image/png',
+        sizes: '512x512',
+        purpose: 'any',
+      },
+      {
+        src: 'd.png',
+        type: 'image/png',
+        sizes: '16x16 32x32',
+        purpose: 'any',
+      },
+    ];
+
+    const mockManifestBusBoyed: BusBoyWebAppManifestLike = {
+      dir: { fieldname: 'dir', value: 'ltr' },
+      name: { fieldname: 'name', value: 'mock' },
+      icons: mockManifestIcons.map(icon => {
+        return {
+          fieldname: 'icons',
+          value: JSON.stringify(icon),
+        };
+      }),
+      screenshots: mockManifestScreenshots.map(screenshot => {
+        return {
+          fieldname: 'screenshots',
+          value: JSON.stringify(screenshot),
+        };
+      }),
+      categories: [
+        { fieldname: 'categories', value: 'books' },
+        { fieldname: 'categories', value: 'blog' },
+      ],
+      prefer_related_applications: {
+        fieldname: 'prefer_related_applications',
+        value: 'true',
+      },
+    };
+
+    const parsedManifest: WebAppManifest =
+      generateObjectFromFormData(mockManifestBusBoyed);
+
+    expect(parsedManifest.dir).toBe('ltr');
+    expect(parsedManifest.prefer_related_applications).toBe(true);
+    expect(parsedManifest.categories).toStrictEqual(['books', 'blog']);
+
+    expect(parsedManifest.icons).toStrictEqual(mockManifestIcons);
+    expect(parsedManifest.screenshots).toStrictEqual(mockManifestScreenshots);
+  });
+
+  it('prefer_related_applications false', () => {
+    const mockManifestBusBoyed: BusBoyWebAppManifestLike = {
+      prefer_related_applications: {
+        fieldname: 'prefer_related_applications',
+        value: 'false',
+      },
+    };
+
+    const parsedManifest = generateObjectFromFormData(mockManifestBusBoyed);
+    expect(parsedManifest.prefer_related_applications).toBe(false);
+  });
+
+  it('categories 1 element', () => {
+    const mockManifestBusBoyed: BusBoyWebAppManifestLike = {
+      categories: { fieldname: 'categories', value: 'books' },
+    };
+
+    const parsedManifest = generateObjectFromFormData(mockManifestBusBoyed);
+    expect(parsedManifest.categories).toStrictEqual(['books']);
+  });
+
+  it('icons 1 element', () => {
+    const icon = {
+      src: 'a.png',
+      type: 'image/png',
+      sizes: '512x512',
+      purpose: 'any',
+    };
+
+    const mockManifestBusBoyed: BusBoyWebAppManifestLike = {
+      icons: {
+        fieldname: 'icons',
+        value: JSON.stringify(icon),
+      },
+    };
+
+    const parsedManifest = generateObjectFromFormData(mockManifestBusBoyed);
+    expect(parsedManifest.icons).toStrictEqual([icon]);
+  });
+
+  it('screenshots 1 element', () => {
+    const screenshot = {
+      src: 'd.png',
+      type: 'image/png',
+      sizes: '16x16 32x32',
+      purpose: 'any',
+    };
+
+    const mockManifestBusBoyed: BusBoyWebAppManifestLike = {
+      screenshots: {
+        fieldname: 'icons',
+        value: JSON.stringify(screenshot),
+      },
+    };
+
+    const parsedManifest = generateObjectFromFormData(mockManifestBusBoyed);
+    expect(parsedManifest.screenshots).toStrictEqual([screenshot]);
+  });
+
+  it('shortcuts 1 element', () => {
+    const shortcut = {
+      name: 'a',
+      short_name: 'a',
+      description: 'desc',
+      url: 'www.example.com',
+      icons: [
+        {
+          src: 'a.png',
+          sizes: '16x16',
+        },
+      ],
+    };
+
+    const mockManifestBusBoyed: BusBoyWebAppManifestLike = {
+      shortcuts: {
+        fieldname: 'shortcuts',
+        value: JSON.stringify(shortcut),
+      },
+    };
+
+    const parsedManifest = generateObjectFromFormData(mockManifestBusBoyed);
+    expect(parsedManifest.shortcuts).toStrictEqual([shortcut]);
+  });
+
+  it('handle number (no element exists atm)', () => {
+    const parsedManifest = generateObjectFromFormData({
+      test: { fieldname: 'test', value: '1' },
+    } as BusBoyWebAppManifestLike);
+
+    expect(parsedManifest.test).toBe(1);
+  });
+});

--- a/__tests__/web.test.ts
+++ b/__tests__/web.test.ts
@@ -24,7 +24,7 @@ const mockManifest: WebAppManifest = {
   screenshots: [],
   categories: [],
   iarc_rating_id: 'ignore',
-  prefer_related_applications: 'true',
+  prefer_related_applications: true,
 };
 
 describe('web.ts', () => {

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -28,28 +28,6 @@ export async function handleIcons(
       return operations;
     }
 
-    // TODO add or remove the generated icons.
-    //each image needs to be copied into two places, a manifest changes and also json write changes in the assets folder
-    // const largestImgEntry = getLargestImgManifestEntry(manifest);
-    // const genIconZip = await getGeneratedIconZip(
-    //   server,
-    //   await getLargestImg(siteUrl, largestImgEntry),
-    //   platform
-    // ).then((zip) => zip);
-
-    // const genIconsStr = await genIconZip?.file("icons.json")?.async("string");
-    // let genIconsList: Array<ManifestImageResource> = [];
-
-    // if (genIconsStr) {
-    //   genIconsList = JSON.parse(genIconsStr)["icons"];
-
-    //   server.log.info(
-    //     "handleImages(): genIconsList = " + JSON.stringify(genIconsList)
-    //   );
-    // }
-
-    // manifest.icons = [];
-
     /*
       1. Attempt to grab icon from manifest
       2. If that fails grab it from the generated icon list
@@ -67,6 +45,14 @@ export async function handleIcons(
 
         if (!icon) {
           server.log.error("the service wasn't able to generate the icon");
+          operations.push(
+            (async () => {
+              return {
+                filePath,
+                success: false,
+              };
+            })()
+          );
           continue;
         }
 

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -62,11 +62,11 @@ export async function handleIcons(
         const height = icon.bitmap.height;
 
         filePath = `images/${iconName}`;
+        manifest.icons[i].src = filePath;
 
         operations.push(
           (async () => {
             try {
-              manifest.icons[i].src = filePath;
               zip.file(
                 filePath,
                 await icon

--- a/src/images.ts
+++ b/src/images.ts
@@ -29,7 +29,8 @@ export async function getJimp(
 
     return Jimp.read(url);
   } catch (e) {
-    server?.log.info(e);
+    server?.log.error(e);
+    server?.log.trace((e as Error).stack);
   }
 
   return undefined;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -81,4 +81,4 @@ interface BusBoyWebAppManifestLike {
   [key: string]: any;
 }
 
-type BusBoyGestalt = WebAppManifest | BusBoyWebAppManifestLike;
+type WebAppManifestGestalt = WebAppManifest | BusBoyWebAppManifestLike;

--- a/src/screenshots.ts
+++ b/src/screenshots.ts
@@ -46,12 +46,13 @@ export async function handleScreenshots(
           screenshot,
           i
         )}`;
+        manifest.screenshots[i].src = filePath;
+
         const screenshotMIME = screenshot.getMIME();
 
         operations.push(
           (async () => {
             try {
-              manifest.screenshots[i].src = filePath;
               zip.file(
                 filePath,
                 await screenshot

--- a/src/screenshots.ts
+++ b/src/screenshots.ts
@@ -28,6 +28,14 @@ export async function handleScreenshots(
           server.log.error(
             "the service wasn't able to generate the screenshot"
           );
+          operations.push(
+            (async () => {
+              return {
+                filePath,
+                success: false,
+              };
+            })()
+          );
           continue;
         }
         const width = screenshot.bitmap.width;
@@ -71,7 +79,7 @@ export async function handleScreenshots(
             return {
               filePath,
               success: false,
-              errror: e as Error,
+              error: e as Error,
             };
           })()
         );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,8 +4,6 @@ export function generateObjectFromFormData(
   busboyBody: BusBoyGestalt,
   server?: FastifyInstance
 ): WebAppManifest {
-  server?.log.info(busboyBody);
-
   const manifest = {} as WebAppManifest;
   const keys = Object.keys(busboyBody);
   const length = keys.length;
@@ -31,23 +29,19 @@ export function generateObjectFromFormData(
       //single elements of the categories array
     } else if (key === 'categories') {
       manifest[key] = [formField.value];
+    } else if ((<string>formField.value).startsWith('{')) {
+      manifest[key] = parseValues(formField.value);
+    } else if (formField.value === 'true') {
+      // support for true and false
+      manifest[key] = true;
+    } else if (formField.value === 'false') {
+      manifest[key] = false;
+    } else if (parseInt(formField.value)) {
+      // check if number, then use number to handle floats
+      manifest[key] = Number(formField.value);
     } else {
-      if ((<string>formField.value).startsWith('{')) {
-        manifest[key] = parseValues(formField.value);
-      } else if (formField.value === 'true') {
-        // support for true and false
-        manifest[key] = true;
-      } else if (formField.value === 'false') {
-        manifest[key] = false;
-      } else if (parseInt(formField.value)) {
-        // check if number, then use number to handle floats
-        manifest[key] = Number(formField.value);
-      } else {
-        manifest[key] = formField.value;
-      }
+      manifest[key] = formField.value;
     }
-
-    server?.log.info(manifest[key]);
   }
 
   return manifest;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 
 export function generateObjectFromFormData(
-  busboyBody: BusBoyGestalt,
+  busboyBody: WebAppManifestGestalt,
   server?: FastifyInstance
 ): WebAppManifest {
   const manifest = {} as WebAppManifest;
@@ -9,7 +9,7 @@ export function generateObjectFromFormData(
   const length = keys.length;
   for (let index = 0; index < length; index++) {
     // the fastify-multipart mapper adds the buffer fields as strings, or arrays of strings for our usage.
-    const key = keys[index] as keyof BusBoyGestalt;
+    const key = keys[index] as keyof BusBoyWebAppManifestLike;
     const formField = busboyBody[key] as BusBoyItem | Array<BusBoyItem>;
 
     server?.log.info(key);

--- a/src/web.ts
+++ b/src/web.ts
@@ -129,7 +129,6 @@ export default function web(server: FastifyInstance) {
           server.log.info({ results, errors });
 
           if (errors.length > 0) {
-            // throw Error(errors.map((result) => result.filePath).toString());
             await writeFile(
               zip,
               JSON.stringify({ results, errors }),


### PR DESCRIPTION
- mostly QoL and test coverage of the more complex logic to 96%
- ensures the base64 fields are replaced with the manifest entry change.
- With the changes I haven't seen the issue where the last entry is not being overwritten in the manifest, so maybe it has to do with a GC'd as the process can take up to 7 seconds.